### PR TITLE
Add filename customisation option to `mix clean_mixer.plantuml`

### DIFF
--- a/lib/mix/tasks/plantuml.ex
+++ b/lib/mix/tasks/plantuml.ex
@@ -8,10 +8,11 @@ defmodule Mix.Tasks.CleanMixer.Plantuml do
   alias CleanMixer.ArchMap
   alias CleanMixer.UI.CLI
 
-  @file_name "clean_mixer"
+  @default_file_name "clean_mixer"
+  def default_file_name, do: @default_file_name
 
-  def plantuml_file_name(), do: "#{@file_name}.plantuml"
-  def image_file_name(), do: "#{@file_name}.png"
+  def plantuml_file_name(file_name \\ @default_file_name), do: "#{file_name}.plantuml"
+  def image_file_name(file_name \\ @default_file_name), do: "#{file_name}.png"
 
   @impl Mix.Task
   def run(args, _options \\ []) do
@@ -24,9 +25,9 @@ defmodule Mix.Tasks.CleanMixer.Plantuml do
     dependency_metrics = MetricsMap.compute_dep_metrics(arch_map, component_metrics)
 
     PlantUMLRenderer.render(arch_map, component_metrics, dependency_metrics, params)
-    |> render_image(plantuml_file_name())
+    |> render_image(plantuml_file_name(params[:output_file]))
 
-    Mix.Shell.IO.info("image file created at #{image_file_name()}")
+    Mix.Shell.IO.info("image file created at #{image_file_name(params[:output_file])}")
   end
 
   defp parse_params(args) do
@@ -45,6 +46,14 @@ defmodule Mix.Tasks.CleanMixer.Plantuml do
           help: "Component names to skip (comma delimited)",
           parser: fn s -> {:ok, String.split(s, ",")} end,
           default: [],
+          required: false
+        ],
+        output_file: [
+          value_name: "OUTPUT_FILE",
+          long: "--output-file",
+          short: "-o",
+          help: "Output file name.",
+          default: @default_file_name,
           required: false
         ]
       ],

--- a/test/mix/tasks/plantuml_test.exs
+++ b/test/mix/tasks/plantuml_test.exs
@@ -4,9 +4,13 @@ defmodule Mix.Tasks.CleanMixer.PlantumlTest do
   alias Mix.Tasks.CleanMixer.Plantuml
   import ExUnit.CaptureIO
 
-  setup do
-    File.rm(Plantuml.image_file_name())
-    File.rm(Plantuml.plantuml_file_name())
+  setup tags do
+    file_name = Map.get(tags, :output_file, Plantuml.default_file_name())
+
+    on_exit(fn ->
+      file_name |> Plantuml.image_file_name() |> File.rm()
+      file_name |> Plantuml.plantuml_file_name() |> File.rm()
+    end)
 
     :ok
   end
@@ -39,5 +43,15 @@ defmodule Mix.Tasks.CleanMixer.PlantumlTest do
 
     plant_uml = Plantuml.plantuml_file_name() |> File.read!()
     assert plant_uml =~ ~s(package "core_domain" {)
+  end
+
+  @tag output_file: "my_custom_clean_mixer_file-#{:rand.uniform()}"
+  test "it supports output file name customisation", %{output_file: output_file} do
+    capture_io(fn ->
+      Mix.Task.rerun("clean_mixer.plantuml", ["--output-file=#{output_file}"])
+    end) =~ output_file
+
+    plant_uml = Plantuml.plantuml_file_name(output_file) |> File.read!()
+    assert String.starts_with?(plant_uml, "@startuml")
   end
 end


### PR DESCRIPTION
Added an option to set the file name for plantuml generator.

```
⚡ mix clean_mixer.plantuml --output-file=docs/cleanmixer
image file created at docs/cleanmixer.png
```

```
⚡ mix clean_mixer.plantuml -o docs/cleanmixer2
image file created at docs/cleanmixer2.png
```

Default behavior remains unchanged
```
⚡ mix clean_mixer.plantuml                    
image file created at clean_mixer.png
```